### PR TITLE
Fix bug preventing setting bind IP with --port

### DIFF
--- a/liquidluck/tools/server.py
+++ b/liquidluck/tools/server.py
@@ -31,6 +31,7 @@ LIVERELOAD = os.path.join(
 
 
 def config(port=None, root=None, permalink=None):
+    global HOST
     global PORT
     global ROOT
     global PERMALINK


### PR DESCRIPTION
The code was previously trying to set HOST to an IP
extracted from the --port argument, but was ineffectual
because the HOST global was not updated.